### PR TITLE
Audience accounts/sc 104607/update GitHub actions to remove deprecation (#1)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Attest/audience-accounts

--- a/src/promtool_check.sh
+++ b/src/promtool_check.sh
@@ -43,6 +43,10 @@ ${check_output}
         echo "${check_payload}" | curl -s -S -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" --header "Content-Type: application/json" --data @- "${check_comment_url}" > /dev/null
     fi
 
-    echo ::set-output name=promtool_output::${check_output}
+    # Updated to new GITHUB_OUTPUT format https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
+    # Modified to support multi-line output https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+    echo "promtool_output<<EOF" >> "$GITHUB_OUTPUT"
+    echo "${check_output}" >> "$GITHUB_OUTPUT"
+    echo "EOF" >> "$GITHUB_OUTPUT"
     exit ${check_exit_code}
 }


### PR DESCRIPTION
* fix: update set output to prevent warning

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/